### PR TITLE
bring bombs/power bombs consistent with log format

### DIFF
--- a/js/locations.json
+++ b/js/locations.json
@@ -155,7 +155,7 @@
   {
     "area": "Chozo",
     "location": "Burn Dome (I. Drone)",
-    "item": "Bombs"
+    "item": "Morph Ball Bomb"
   },
   {
     "area": "Chozo",
@@ -584,7 +584,7 @@
   {
     "area": "Mines",
     "location": "Central Dynamo",
-    "item": "Power Bombs",
+    "item": "Power Bomb",
     "requires": [
       ["wave", "ice"]
     ]


### PR DESCRIPTION
Fix the wording in locations.json to be consistent with the wording in the log file:

```
Randomizer V3.2
Seed: 891470660
Excluded pickups: 5 19 28
...
Chozo - - - Burn Dome (I. Drone) - - - - - - - - - Morph Ball Bomb
...
Tallon  - - Frigate Crash Site - - - - - - - - - - Power Bomb
```